### PR TITLE
.envで挙動を変えられるように

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,15 @@
 HOST_NAME="your domain"
 API_TOKEN="your api server"
-IS_DRY_RYN=true
+BOT_NAME="your bot account name"
+API_LIMIT=30
+IS_DRY_RUN=true
 INTERVALS=30
 IS_REUPLOAD=false
 IS_CONVERT=false
+VISIBILITY_ADD="public"
+VISIBILITY_UPDATE="home"
+VISIBILITY_DELETE="home"
+USE_CW_ADD=true
+USE_CW_UPDATE=true
+USE_CW_DELETE=true
+LOCAL_ONLY=true

--- a/README.md
+++ b/README.md
@@ -3,3 +3,15 @@
 Misskey インスタンスに絵文字が追加された事を知らせるBOTです。
 私用する際は、`.env.example` をコピーし `.env` を作成して利用してください
 `pnpm start` で起動できます。
+
+Misskey バージョン 2023.12.1 以降はアクセストークンに以下の権限が必要です。
+```js
+"permission": [
+        "read:admin:show-moderation-log",
+        "write:notes",
+        "read:drive",
+        "write:drive",
+        "read:admin:emoji",
+        "write:admin:emoji"
+    ]
+```


### PR DESCRIPTION
## 変更点

-  .env でノートの公開範囲とCWを変えられるように（追加・更新・削除ごとに変えられます）
-  ハードコーディングのいくつかを .env に移動
-  .env.example の DRY_RUNの誤字を修正
-  モデレーションログを新しい順に通知していたのを古い順に修正

## 変更の理由

サーバー内で大量の追加・更新・削除があったときに LTL が混乱してしまうため、その対策として公開範囲を .env で切り替えられるようにしました。CW を設けるのもタイムラインの占有を緩和するためです。

よろしくお願いします。